### PR TITLE
Minor fix of one malformed record

### DIFF
--- a/game-of-thrones-deaths-data.csv
+++ b/game-of-thrones-deaths-data.csv
@@ -4476,7 +4476,7 @@ order,season,episode,character_killed,killer,method,method_cat,reason,location,a
 4475,8,3,Wight,Brienne of Tarth,Sword (Oathkeeper),Blade,Killed during the Battle of Winterfell,Winterfell,None,1
 4476,8,3,Wight,Jaime Lannister,Sword,Blade,Killed during the Battle of Winterfell,Winterfell,None,1
 4477,8,3,Wight,Jaime Lannister,Sword,Blade,Killed during the Battle of Winterfell,Winterfell,None,1
-4478,8,3,Wight,Brienne of Tarth,Sword (Oathkeeper),Blade,Killed during the Battle of Winterfell,Winterfell,None,
+4478,8,3,Wight,Brienne of Tarth,Sword (Oathkeeper),Blade,Killed during the Battle of Winterfell,Winterfell,None,1
 4479,8,3,Wight,Jaime Lannister,Sword,Blade,Killed during the Battle of Winterfell,Winterfell,None,1
 4480,8,3,Wight,Jorah Mormont,Sword (Heartsbane),Blade,Killed during the Battle of Winterfell,Winterfell,None,1
 4481,8,3,Wight,Sam Tarly,Sword,Blade,Killed during the Battle of Winterfell,Winterfell,None,1


### PR DESCRIPTION
Added missing 'importance' value to record with order=4478. I bumped into this after converting the data to JSON and then trying to parse the JSON into a strongly typed record (where all fields were expected to be present). The good news is that this line was the ONLY malformed record I found.